### PR TITLE
Add console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,9 @@ setup(
 
     data_files=[],
 
-    entry_points={},
+    entry_points={
+        'console_scripts': [
+            'behave2cucumber = behave2cucumber.behave2cucumber.__main__:main
+        ],
+    },
 )


### PR DESCRIPTION
This creates a wrapper console script which allows behave2cucumber to be called directly from the commandline without having to invoke "python -m"

Note, the main function should be standalone e.g. not depend on any global level input (to avoid any issues).
so the main function should just be:

if __name__ == '__main__':
     main()

and any sys.argv input checking should happen inside of main()