### PR TITLE
Avoid errors when elements is not present in a feature

### DIFF
--- a/behave2cucumber/__init__.py
+++ b/behave2cucumber/__init__.py
@@ -64,8 +64,9 @@ def convert(json_file, remove_background=False, duration_format=False, deduplica
     # Option to remove background element because behave pushes it steps to all scenarios already
     if remove_background:
         for feature in json_file:
-            if feature['elements'][0]['type'] == 'background':
-                feature['elements'].pop(0)
+            if feature.get('elements'):
+                if feature['elements'][0].get('type') == 'background':
+                    feature['elements'].pop(0)
 
     if deduplicate:
         def check_dupe(current_feature, current_scenario, previous_scenario):
@@ -89,7 +90,7 @@ def convert(json_file, remove_background=False, duration_format=False, deduplica
             scenarios = []
 
             # For each scenario in the feature
-            for scenario in feature['elements']:
+            for scenario in feature.get('elements', []):
                 # Append the scenario to the working list
                 scenarios.append(scenario)
 

--- a/behave2cucumber/__init__.py
+++ b/behave2cucumber/__init__.py
@@ -9,7 +9,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 '''
 
 
-def convert(json_file, remove_background=False, duration_format=False, deduplicate=False):
+def convert(json_file, remove_background=False, duration_format=False, deduplicate=False, remove_empty=False):
     # json_nodes are the scopes available in behave/cucumber json: Feature -> elements(Scnerios) -> Steps
     json_nodes = ['feature', 'elements', 'steps']
     # These fields doesn't exist in cucumber report, there-fore when converting from behave, we need to delete these
@@ -66,6 +66,20 @@ def convert(json_file, remove_background=False, duration_format=False, deduplica
         for feature in json_file:
             if feature['elements'][0]['type'] == 'background':
                 feature['elements'].pop(0)
+
+    if remove_empty:
+        for feature in json_file:
+            # Create a working list
+            scenarios = []
+
+            # For each scenario in the feature
+            for scenario in feature['elements']:
+                # Add the scenario only if there are steps
+                if len(scenario['steps']) > 0:
+                    scenarios.append(scenario)
+
+            # Replace the existing list with the working list
+            feature['elements'] = scenarios
 
     if deduplicate:
         def check_dupe(current_feature, current_scenario, previous_scenario):

--- a/behave2cucumber/__main__.py
+++ b/behave2cucumber/__main__.py
@@ -24,10 +24,10 @@ log.addHandler(consoleHandler)
 
 
 options = {
-    "short": "hd:i:o:rfD",
+    "short": "hd:i:o:rfDe",
     "long": [
         "help", "debug=", "infile=", "outfile=", "remove-background",
-        "format-duration","deduplicate"
+        "format-duration", "deduplicate", "remove-empty"
     ],
     "descriptions": [
         "Print help message",
@@ -36,7 +36,8 @@ options = {
         "Specify the output JSON, otherwise use stdout",
         "Remove background steps from output",
         "Format the duration",
-        "Remove duplicate scenarios caused by @autoretry"
+        "Remove duplicate scenarios caused by @autoretry",
+        "Remove scenarios which contain no steps"
     ]
 }
 
@@ -87,6 +88,7 @@ def main(argv):
     remove_background = False
     duration_format = False
     deduplicate = False
+    remove_empty = False
 
     for opt, arg in opts:
         if opt in ("-i", "--infile"):
@@ -104,6 +106,9 @@ def main(argv):
         if opt in ("-D", "--deduplicate"):
             log.info("Deduplicate: Enabled")
             deduplicate = True
+        if opt in ("-e", "--remove-empty"):
+            log.info("Remove Empty: Enabled")
+            remove_empty = True
 
     if infile is None:
         log.critical("No input JSON provided.")
@@ -114,7 +119,8 @@ def main(argv):
         cucumber_output = convert(json.load(f),
                                   remove_background=remove_background,
                                   duration_format=duration_format,
-                                  deduplicate=deduplicate)
+                                  deduplicate=deduplicate,
+                                  remove_empty=remove_empty)
 
     if outfile is not None:
         with open(outfile, 'w') as f:

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,15 @@ here = path.abspath(path.dirname(__file__))
 setup(
     name='behave2cucumber',
 
-    version='1.0.3',
+    version='1.0.4.1',
 
-    description='Behave to Cucumber json converter',
+    description='Behave to Cucumber json converter (lawnmowerlatte fork)',
     long_description='This project helps solving the incompatibilty of Behave\'s genereated json reports '
                      'to tools using Cucumber json reports. '
-                     'Its done by reformatting the Behave json to Cucumber json.',
+                     'Its done by reformatting the Behave json to Cucumber json. '
+                     'This fork contains a fix by lawnmowerlatte which has not been pulled into the main repo.',
 
-    url='https://github.com/behalf-oss/behave2cucumber',
+    url='https://github.com/lawnmowerlatte/behave2cucumber',
 
     author='Andrey Goldgamer, Zvika Messing',
     author_email='andrey.goldgamer@behalf.com, zvika@behalf.com ',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 setup(
-    name='behave2cucumber',
+    name='behave2cucumber-lawnmowerlatte',
 
     version='1.0.4.1',
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = path.abspath(path.dirname(__file__))
 setup(
     name='behave2cucumber-lawnmowerlatte',
 
-    version='1.0.4.1',
+    version='1.0.4.2',
 
     description='Behave to Cucumber json converter (lawnmowerlatte fork)',
     long_description='This project helps solving the incompatibilty of Behave\'s genereated json reports '


### PR DESCRIPTION
If there are no tests run, the elements field is not present in the behave output which causes behave2cucumber to generate an error. This change avoids this error by checking before accessing.